### PR TITLE
Update plugin to newer Buildarr API standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
       - id: black
   # TODO: Re-enable when the cause for the inconsistent results is figured out.
   # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: "v1.1.1"
+  #   rev: "v1.2.0"
   #   hooks:
   #     - id: mypy
   #       additional_dependencies:
   #         - types-requests==2.28.11.17
-  #         - buildarr==0.4.0
+  #         - buildarr==0.5.0
   - repo: https://github.com/python-poetry/poetry
     rev: "1.4.2"
     hooks:

--- a/buildarr_prowlarr/api.py
+++ b/buildarr_prowlarr/api.py
@@ -90,13 +90,16 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
     """
 
     url = f"{host_url}/initialize.js"
+
     logger.debug("GET %s", url)
+
     res = requests.get(
         url,
         headers={"X-Api-Key": api_key} if api_key else None,
-        timeout=state.config.buildarr.request_timeout,
+        timeout=state.request_timeout,
         allow_redirects=False,
     )
+
     if res.status_code != HTTPStatus.OK:
         logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, res.text)
         if res.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FOUND):
@@ -109,9 +112,12 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
             f"Unable to retrieve 'initialize.js': {error_message}",
             status_code=status_code,
         )
+
     res_match = re.match(INITIALIZE_JS_RES_PATTERN, res.text)
     if not res_match:
         raise RuntimeError(f"No matches for 'initialize.js' parsing: {res.text}")
     res_json = json5.loads(res_match.group(1))
+
     logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+
     return res_json

--- a/buildarr_prowlarr/config/settings/__init__.py
+++ b/buildarr_prowlarr/config/settings/__init__.py
@@ -123,6 +123,7 @@ class ProwlarrSettings(ProwlarrConfigBase):
                     secrets,
                     remote.notifications,
                 ),
+                self.tags.delete_remote(f"{tree}.tags", secrets, remote.tags),
                 self.general.delete_remote(f"{tree}.general", secrets, remote.general),
                 self.ui.delete_remote(f"{tree}.ui", secrets, remote.ui),
             ],

--- a/buildarr_prowlarr/config/settings/__init__.py
+++ b/buildarr_prowlarr/config/settings/__init__.py
@@ -103,7 +103,5 @@ class ProwlarrSettings(ProwlarrConfigBase):
                     remote.ui,
                     check_unmanaged=check_unmanaged,
                 ),
-                # TODO: destroy indexers
-                # TODO: destroy tags
             ],
         )

--- a/buildarr_prowlarr/config/settings/__init__.py
+++ b/buildarr_prowlarr/config/settings/__init__.py
@@ -57,8 +57,8 @@ class ProwlarrSettings(ProwlarrConfigBase):
         check_unmanaged: bool = False,
     ) -> bool:
         # Overload base function to guarantee execution order of section updates.
-        # 1. Tags must be created before everything else, and destroyed after they
-        #    are no longer referenced elsewhere.
+        # 1. Tags must be created before everything else.
+        # 2. Apps/Sync Profiles must be created before Indexers.
         return any(
             [
                 self.tags.update_remote(
@@ -103,5 +103,27 @@ class ProwlarrSettings(ProwlarrConfigBase):
                     remote.ui,
                     check_unmanaged=check_unmanaged,
                 ),
+            ],
+        )
+
+    def delete_remote(self, tree: str, secrets: ProwlarrSecrets, remote: Self) -> bool:
+        # Overload base function to guarantee execution order of section deletions.
+        # 1. Indexers must be deleted before Apps/Sync Profiles.
+        return any(
+            [
+                self.indexers.delete_remote(f"{tree}.indexers", secrets, remote.indexers),
+                self.apps.delete_remote(f"{tree}.apps", secrets, remote.apps),
+                self.download_clients.delete_remote(
+                    f"{tree}.download_clients",
+                    secrets,
+                    remote.download_clients,
+                ),
+                self.notifications.delete_remote(
+                    f"{tree}.notifications",
+                    secrets,
+                    remote.notifications,
+                ),
+                self.general.delete_remote(f"{tree}.general", secrets, remote.general),
+                self.ui.delete_remote(f"{tree}.ui", secrets, remote.ui),
             ],
         )

--- a/buildarr_prowlarr/config/settings/download_clients/base.py
+++ b/buildarr_prowlarr/config/settings/download_clients/base.py
@@ -234,12 +234,6 @@ class DownloadClient(ProwlarrConfigBase):
             return True
         return False
 
-    def _delete_remote(
-        self,
-        tree: str,
-        secrets: ProwlarrSecrets,
-        downloadclient_id: int,
-    ) -> None:
-        logger.info("%s: (...) -> (deleted)", tree)
+    def _delete_remote(self, secrets: ProwlarrSecrets, downloadclient_id: int) -> None:
         with prowlarr_api_client(secrets=secrets) as api_client:
             prowlarr.DownloadClientApi(api_client).delete_download_client(id=downloadclient_id)

--- a/buildarr_prowlarr/config/settings/download_clients/torrent.py
+++ b/buildarr_prowlarr/config/settings/download_clients/torrent.py
@@ -23,7 +23,7 @@ from logging import getLogger
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set
 
 from buildarr.config import RemoteMapEntry
-from buildarr.types import BaseEnum, BaseIntEnum, NonEmptyStr, Password, Port
+from buildarr.types import BaseEnum, NonEmptyStr, Password, Port
 from pydantic import validator
 
 from ....types import LowerCaseNonEmptyStr
@@ -72,7 +72,7 @@ class FloodMediaTag(BaseEnum):
     network = 6
 
 
-class FreeboxPriority(BaseIntEnum):
+class FreeboxPriority(BaseEnum):
     last = 0
     first = 1
 
@@ -565,7 +565,7 @@ class FreeboxDownloadClient(TorrentDownloadClient):
     Adding a category specific to Prowlarr avoids conflicts with unrelated non-Prowlarr downloads.
     """
 
-    priority: FreeboxPriority = FreeboxPriority.last
+    client_priority: FreeboxPriority = FreeboxPriority.last
     """
     Priority to use when adding a download to the client.
     """
@@ -607,7 +607,7 @@ class FreeboxDownloadClient(TorrentDownloadClient):
                 "category",
                 {"is_field": True, "decoder": lambda v: v or None, "encoder": lambda v: v or ""},
             ),
-            ("priority", "priority", {"is_field": True}),
+            ("client_priority", "priority", {"is_field": True}),
             ("add_paused", "addPaused", {"is_field": True}),
             (
                 "category_mappings",

--- a/buildarr_prowlarr/config/settings/indexers/__init__.py
+++ b/buildarr_prowlarr/config/settings/indexers/__init__.py
@@ -43,8 +43,6 @@ class ProwlarrIndexersSettings(ProwlarrConfigBase):
         check_unmanaged: bool = False,
     ) -> bool:
         # Overload base function to guarantee execution order of section updates.
-        # 1. Tags must be created before everything else, and destroyed after they
-        #    are no longer referenced elsewhere.
         return any(
             [
                 self.proxies.update_remote(
@@ -59,7 +57,14 @@ class ProwlarrIndexersSettings(ProwlarrConfigBase):
                     remote.indexers,
                     check_unmanaged=check_unmanaged,
                 ),
-                # TODO: destroy indexers
-                # TODO: destroy tags
+            ],
+        )
+
+    def delete_remote(self, tree: str, secrets: ProwlarrSecrets, remote: Self) -> bool:
+        # Overload base function to guarantee execution order of section deletions.
+        return any(
+            [
+                self.indexers.delete_remote(f"{tree}.indexers", secrets, remote.indexers),
+                self.proxies.delete_remote(f"{tree}.proxies", secrets, remote.proxies),
             ],
         )

--- a/buildarr_prowlarr/config/settings/tags.py
+++ b/buildarr_prowlarr/config/settings/tags.py
@@ -51,17 +51,6 @@ class ProwlarrTagsSettings(ProwlarrConfigBase):
     in this configuration section.
     """
 
-    delete_unused: bool = False
-    """
-    Delete tags that are not used by any resource in Buildarr.
-
-    Note that tags not being used in Buildarr are not necessarily
-    unused by Prowlarr, so be careful about when to use this option.
-
-    Prowlarr appears to periodically clean up unused tags,
-    so in most cases there is no need to enable this option.
-    """
-
     definitions: Set[NonEmptyStr] = set()
     """
     Define tags that are used within Buildarr here.
@@ -83,9 +72,7 @@ class ProwlarrTagsSettings(ProwlarrConfigBase):
         remote: Self,
         check_unmanaged: bool = False,
     ) -> bool:
-        # This only does creations and updates.
-        # Deletes (and empty tag list prints) are done AFTER all other modifications are made.
-        # TODO: Implement tag deletions.
+        # This only does creations and updates, as Prowlarr automatically cleans up unused tags.
         changed = False
         with prowlarr_api_client(secrets=secrets) as api_client:
             tag_api = prowlarr.TagApi(api_client)

--- a/docs/configuration/host.md
+++ b/docs/configuration/host.md
@@ -9,5 +9,3 @@
         - api_key
         - version
         - settings
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/apps/applications.md
+++ b/docs/configuration/settings/apps/applications.md
@@ -5,8 +5,6 @@
       members:
         - delete_unmanaged
         - definitions
-      show_root_heading: false
-      show_source: false
 
 ## Configuration
 
@@ -18,8 +16,6 @@
         - sync_level
         - sync_categories
         - tags
-      show_root_heading: false
-      show_source: false
 
 ## LazyLibrarian
 
@@ -29,8 +25,6 @@
         - type
         - api_key
         - sync_categories
-      show_root_heading: false
-      show_source: false
 
 ## Lidarr
 
@@ -40,8 +34,6 @@
         - type
         - api_key
         - sync_categories
-      show_root_heading: false
-      show_source: false
 
 ## Mylar
 
@@ -51,8 +43,6 @@
         - type
         - api_key
         - sync_categories
-      show_root_heading: false
-      show_source: false
 
 ## Radarr
 
@@ -62,8 +52,6 @@
         - type
         - api_key
         - sync_categories
-      show_root_heading: false
-      show_source: false
 
 ## Readarr
 
@@ -73,8 +61,6 @@
         - type
         - api_key
         - sync_categories
-      show_root_heading: false
-      show_source: false
 
 ## Sonarr
 
@@ -86,8 +72,6 @@
         - api_key
         - sync_categories
         - anime_sync_categories
-      show_root_heading: false
-      show_source: false
 
 ## Whisparr
 
@@ -97,5 +81,3 @@
         - type
         - api_key
         - sync_categories
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/apps/sync-profiles.md
+++ b/docs/configuration/settings/apps/sync-profiles.md
@@ -5,8 +5,6 @@
       members:
         - delete_unmanaged
         - definitions
-      show_root_heading: false
-      show_source: false
 
 ## Configuration
 
@@ -17,5 +15,3 @@
         - enable_interactive_search
         - enable_automatic_search
         - minimum_seeders
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/download-clients.md
+++ b/docs/configuration/settings/download-clients.md
@@ -198,7 +198,7 @@ peer-to-peer file sharing protocol to retrieve media files.
         - app_token
         - destination_directory
         - category
-        - priority
+        - client_priority
         - add_paused
         - category_mappings
       show_root_heading: false

--- a/docs/configuration/settings/download-clients.md
+++ b/docs/configuration/settings/download-clients.md
@@ -5,8 +5,6 @@
       members:
         - delete_unmanaged
         - definitions
-      show_root_heading: false
-      show_source: false
 
 ## Configuring download clients
 
@@ -16,8 +14,6 @@
         - enable
         - priority
         - tags
-      show_root_heading: false
-      show_source: false
 
 ## Usenet download clients
 
@@ -36,8 +32,6 @@ These download clients retrieve media using the [Usenet](https://en.wikipedia.or
         - password
         - category
         - directory
-      show_root_heading: false
-      show_source: false
 
 ## NZBGet
 
@@ -55,8 +49,6 @@ These download clients retrieve media using the [Usenet](https://en.wikipedia.or
         - client_priority
         - add_paused
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## NZBVortex
 
@@ -72,8 +64,6 @@ These download clients retrieve media using the [Usenet](https://en.wikipedia.or
         - category
         - client_priority
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## Pneumatic
 
@@ -82,8 +72,6 @@ These download clients retrieve media using the [Usenet](https://en.wikipedia.or
       members:
         - type
         - nzb_folder
-      show_root_heading: false
-      show_source: false
 
 ## SABnzbd
 
@@ -99,8 +87,6 @@ These download clients retrieve media using the [Usenet](https://en.wikipedia.or
         - category
         - client_priority
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## Usenet Blackhole
 
@@ -109,8 +95,6 @@ These download clients retrieve media using the [Usenet](https://en.wikipedia.or
       members:
         - type
         - nzb_folder
-      show_root_heading: false
-      show_source: false
 
 ## Torrent download clients
 
@@ -128,8 +112,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - use_ssl
         - rpc_path
         - secret_token
-      show_root_heading: false
-      show_source: false
 
 ## Deluge
 
@@ -145,8 +127,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - category
         - client_priority
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## Download Station (Torrent)
 
@@ -161,8 +141,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - password
         - category
         - directory
-      show_root_heading: false
-      show_source: false
 
 ## Flood
 
@@ -181,8 +159,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - additional_tags
         - add_paused
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## Freebox
 
@@ -201,8 +177,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - client_priority
         - add_paused
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## Hadouken
 
@@ -218,8 +192,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - password
         - category
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## qBittorrent
 
@@ -239,8 +211,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - sequential_order
         - first_and_last_first
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## RTorrent (ruTorrent)
 
@@ -258,8 +228,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - client_priority
         - add_stopped
         - category_mappings
-      show_root_heading: false
-      show_source: false
 
 ## Torrent Blackhole
 
@@ -271,8 +239,6 @@ peer-to-peer file sharing protocol to retrieve media files.
         - save_magnet_files
         - magnet_file_extension
         - read_only
-      show_root_heading: false
-      show_source: false
 
 ## Transmission/Vuze
 
@@ -295,8 +261,6 @@ To use Vuze, set the `type` attribute in the download client to `vuze`.
         - directory
         - client_priority
         - add_paused
-      show_root_heading: false
-      show_source: false
 
 ## uTorrent
 
@@ -314,5 +278,3 @@ To use Vuze, set the `type` attribute in the download client to `vuze`.
         - client_priority
         - initial_state
         - category_mappings
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/general.md
+++ b/docs/configuration/settings/general.md
@@ -44,8 +44,6 @@ Take care when changing these settings.
         - use_ssl
         - url_base
         - instance_name
-      show_root_heading: false
-      show_source: false
 
 ## Security
 
@@ -57,8 +55,6 @@ Take care when changing these settings.
         - username
         - password
         - certificate_validation
-      show_root_heading: false
-      show_source: false
 
 ## Proxy
 
@@ -73,8 +69,6 @@ Take care when changing these settings.
         - password
         - ignored_addresses
         - bypass_proxy_for_local_addresses
-      show_root_heading: false
-      show_source: false
 
 ## Logging
 
@@ -82,8 +76,6 @@ Take care when changing these settings.
     options:
       members:
         - log_level
-      show_root_heading: false
-      show_source: false
 
 ## Analytics
 
@@ -91,8 +83,6 @@ Take care when changing these settings.
     options:
       members:
         - send_anonymous_usage_data
-      show_root_heading: false
-      show_source: false
 
 ## Updates
 
@@ -103,8 +93,6 @@ Take care when changing these settings.
         - automatic
         - mechanism
         - script_path
-      show_root_heading: false
-      show_source: false
 
 ## Backup
 
@@ -114,5 +102,3 @@ Take care when changing these settings.
         - folder
         - interval
         - retention
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/indexers/indexers.md
+++ b/docs/configuration/settings/indexers/indexers.md
@@ -5,8 +5,6 @@
       members:
         - delete_unmanaged
         - definitions
-      show_root_heading: false
-      show_source: false
 
 ## Adding indexers to Buildarr
 
@@ -69,5 +67,3 @@ prowlarr:
         - tags
         - fields
         - secret_fields
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/indexers/proxies.md
+++ b/docs/configuration/settings/indexers/proxies.md
@@ -5,8 +5,6 @@
       members:
         - delete_unmanaged
         - definitions
-      show_root_heading: false
-      show_source: false
 
 ## Configuring indexer proxies
 
@@ -14,8 +12,6 @@
     options:
       members:
         - tags
-      show_root_heading: false
-      show_source: false
 
 ## FlareSolverr
 
@@ -25,8 +21,6 @@
         - type
         - host_url
         - request_timeout
-      show_root_heading: false
-      show_source: false
 
 ## HTTP proxy
 
@@ -38,8 +32,6 @@
         - port
         - username
         - password
-      show_root_heading: false
-      show_source: false
 
 ## SOCKS4 proxy
 
@@ -51,8 +43,6 @@
         - port
         - username
         - password
-      show_root_heading: false
-      show_source: false
 
 ## SOCKS5 proxy
 
@@ -64,5 +54,3 @@
         - port
         - username
         - password
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/notifications.md
+++ b/docs/configuration/settings/notifications.md
@@ -14,8 +14,6 @@ some kind of event (or problem) occurs.
         - on_health_issue
         - include_health_warnings
         - on_application_update
-      show_root_heading: false
-      show_source: false
 
 ## Apprise
 
@@ -29,8 +27,6 @@ some kind of event (or problem) occurs.
         - apprise_tags
         - auth_username
         - auth_password
-      show_root_heading: false
-      show_source: false
 
 ## Boxcar
 
@@ -39,8 +35,6 @@ some kind of event (or problem) occurs.
       members:
         - type
         - access_token
-      show_root_heading: false
-      show_source: false
 
 ## Custom Script
 
@@ -49,8 +43,6 @@ some kind of event (or problem) occurs.
       members:
         - type
         - path
-      show_root_heading: false
-      show_source: false
 
 ## Discord
 
@@ -64,8 +56,6 @@ some kind of event (or problem) occurs.
         - host
         - on_grab_fields
         - on_import_fields
-      show_root_heading: false
-      show_source: false
 
 ## Email
 
@@ -82,8 +72,6 @@ some kind of event (or problem) occurs.
         - recipient_addresses
         - cc_addresses
         - bcc_addresses
-      show_root_heading: false
-      show_source: false
 
 ## Gotify
 
@@ -94,8 +82,6 @@ some kind of event (or problem) occurs.
         - server
         - app_token
         - priority
-      show_root_heading: false
-      show_source: false
 
 ## Join
 
@@ -106,8 +92,6 @@ some kind of event (or problem) occurs.
         - api_key
         - device_names
         - priority
-      show_root_heading: false
-      show_source: false
 
 ## Mailgun
 
@@ -120,8 +104,6 @@ some kind of event (or problem) occurs.
         - from_address
         - sender_domain
         - recipient_addresses
-      show_root_heading: false
-      show_source: false
 
 ## Notifiarr
 
@@ -130,8 +112,6 @@ some kind of event (or problem) occurs.
       members:
         - type
         - api_key
-      show_root_heading: false
-      show_source: false
 
 ## ntfy
 
@@ -146,8 +126,6 @@ some kind of event (or problem) occurs.
         - topics
         - ntfy_tags
         - click_url
-      show_root_heading: false
-      show_source: false
 
 ## Prowl
 
@@ -157,8 +135,6 @@ some kind of event (or problem) occurs.
         - type
         - api_key
         - priority
-      show_root_heading: false
-      show_source: false
 
 ## Pushbullet
 
@@ -170,8 +146,6 @@ some kind of event (or problem) occurs.
         - device_ids
         - channel_tags
         - sender_id
-      show_root_heading: false
-      show_source: false
 
 ## Pushover
 
@@ -186,8 +160,6 @@ some kind of event (or problem) occurs.
         - retry
         - expire
         - sound
-      show_root_heading: false
-      show_source: false
 
 ## SendGrid
 
@@ -198,8 +170,6 @@ some kind of event (or problem) occurs.
         - api_key
         - from_address
         - recipient_addresses
-      show_root_heading: false
-      show_source: false
 
 ## Slack
 
@@ -211,8 +181,6 @@ some kind of event (or problem) occurs.
         - username
         - icon
         - channel
-      show_root_heading: false
-      show_source: false
 
 ## Telegram
 
@@ -223,8 +191,6 @@ some kind of event (or problem) occurs.
         - bot_token
         - chat_id
         - send_silently
-      show_root_heading: false
-      show_source: false
 
 ## Twitter
 
@@ -238,8 +204,6 @@ some kind of event (or problem) occurs.
         - access_token_secret
         - mention
         - direct_message
-      show_root_heading: false
-      show_source: false
 
 ## Webhook
 
@@ -251,5 +215,3 @@ some kind of event (or problem) occurs.
         - method
         - username
         - password
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/notifications.md
+++ b/docs/configuration/settings/notifications.md
@@ -58,7 +58,7 @@ some kind of event (or problem) occurs.
     options:
       members:
         - type
-        - webook_url
+        - webhook_url
         - username
         - avatar
         - host

--- a/docs/configuration/settings/tags.md
+++ b/docs/configuration/settings/tags.md
@@ -4,5 +4,3 @@
     options:
       members:
         - definitions
-      show_root_heading: false
-      show_source: false

--- a/docs/configuration/settings/tags.md
+++ b/docs/configuration/settings/tags.md
@@ -3,7 +3,6 @@
 ##### ::: buildarr_prowlarr.config.settings.tags.ProwlarrTagsSettings
     options:
       members:
-        - delete_unused
         - definitions
       show_root_heading: false
       show_source: false

--- a/docs/configuration/settings/ui.md
+++ b/docs/configuration/settings/ui.md
@@ -12,5 +12,3 @@
         - enable_color_impaired_mode
         - theme
         - ui_language
-      show_root_heading: false
-      show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,9 @@ plugins:
         python:
           options:
             docstring_style: google
+            show_root_heading: false
+            show_source: false
+            show_bases: false
 
 markdown_extensions:
   - toc:

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,6 +89,21 @@ typing-extensions = ">=4.0.1"
 watchdog = ">=3.0.0"
 
 [[package]]
+name = "buildarr-sonarr"
+version = "0.5.0"
+description = "Sonarr PVR plugin for Buildarr"
+category = "main"
+optional = true
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "buildarr_sonarr-0.5.0-py3-none-any.whl", hash = "sha256:3e7fed1a4d7f3adef39fd9e2a8ef23522512826aed9f63347698cfa24cd293d1"},
+    {file = "buildarr_sonarr-0.5.0.tar.gz", hash = "sha256:2535af15215889959a8c1e68571c02bac8369fe8ba03886c7a369ddc912ed75e"},
+]
+
+[package.dependencies]
+buildarr = ">=0.5.0,<0.6.0"
+
+[[package]]
 name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1065,7 +1080,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+sonarr = ["buildarr-sonarr"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "f2c6e68fe1a98ccdd4ae72debc96156f27f4835a388e3b6883b54e022c126351"
+content-hash = "da6aa37a13379af792255cdbbf1269bfa742b39ae2467e4cc75487e3da53fa73"

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,14 +65,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "buildarr"
-version = "0.4.0"
+version = "0.5.0"
 description = "Constructs and configures Arr PVR stacks"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "buildarr-0.4.0-py3-none-any.whl", hash = "sha256:d7abdf31cbd20afcf019c6b661fd140a67c645fd465dd0d0953940c1df12e73b"},
-    {file = "buildarr-0.4.0.tar.gz", hash = "sha256:8ac557898166e8701d29e2012d9317c293c123e2a705d0ba90b96c5c8439d1ea"},
+    {file = "buildarr-0.5.0-py3-none-any.whl", hash = "sha256:86a2ae4503f624987bd8e80dedffe069b4d0cbc16f78738e3ffccda894d459cc"},
+    {file = "buildarr-0.5.0.tar.gz", hash = "sha256:c33ed1a080d77d135306c4bef7aef98657828b1e71f249d6360bb99db8dddb5e"},
 ]
 
 [package.dependencies]
@@ -87,21 +87,6 @@ schedule = ">=1.1.0"
 stevedore = ">=4.0.0"
 typing-extensions = ">=4.0.1"
 watchdog = ">=3.0.0"
-
-[[package]]
-name = "buildarr-sonarr"
-version = "0.4.1"
-description = "Sonarr PVR plugin for Buildarr"
-category = "main"
-optional = true
-python-versions = ">=3.8,<4.0"
-files = [
-    {file = "buildarr_sonarr-0.4.1-py3-none-any.whl", hash = "sha256:0c20b3bd0b39ebf79c3c22c7d61b60ede0ac21d06506f58eccc4fa40c7c8f7b6"},
-    {file = "buildarr_sonarr-0.4.1.tar.gz", hash = "sha256:731df277f18eaebc85aff8f24627bc1bb1e48e75520e73f7bdb4f93ab39a8664"},
-]
-
-[package.dependencies]
-buildarr = ">=0.4.0,<0.5.0"
 
 [[package]]
 name = "certifi"
@@ -278,18 +263,18 @@ wmi = ["wmi (>=1.5.1,<2.0.0)"]
 
 [[package]]
 name = "email-validator"
-version = "1.3.1"
+version = "2.0.0"
 description = "A robust email address syntax and deliverability validation library."
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 files = [
-    {file = "email_validator-1.3.1-py2.py3-none-any.whl", hash = "sha256:49a72f5fa6ed26be1c964f0567d931d10bf3fdeeacdf97bc26ef1cd2a44e0bda"},
-    {file = "email_validator-1.3.1.tar.gz", hash = "sha256:d178c5c6fa6c6824e9b04f199cf23e79ac15756786573c190d2ad13089411ad2"},
+    {file = "email_validator-2.0.0-py3-none-any.whl", hash = "sha256:07c61b62ee446e39274b18204afa8e422baf64570776045272b04d10c02f64f6"},
+    {file = "email_validator-2.0.0.tar.gz", hash = "sha256:f4904f4145c11f8de5897afbb8d7db4b465c57f13db1c8c106c16d02bceebd9a"},
 ]
 
 [package.dependencies]
-dnspython = ">=1.15.0"
+dnspython = ">=2.0.0"
 idna = ">=2.0.0"
 
 [[package]]
@@ -312,14 +297,14 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "griffe"
-version = "0.26.0"
+version = "0.27.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "griffe-0.26.0-py3-none-any.whl", hash = "sha256:38f3f6bbe834501cc199a07b7b7e0e2550aaf19a9d1ee27acf879027e47c9b9e"},
-    {file = "griffe-0.26.0.tar.gz", hash = "sha256:08675ffe8c17139e7769e950dd21f8e98a2e76205cbbd2911d5dec26d2cbf1be"},
+    {file = "griffe-0.27.0-py3-none-any.whl", hash = "sha256:f3a5726e2d5876ac882d48ff9ca1a95c5bc267196a8f114263e66e234141bb84"},
+    {file = "griffe-0.27.0.tar.gz", hash = "sha256:dcf3cc4205f33cbb16095324803a6904e0b293cd1630ceab4b66a9115af6b818"},
 ]
 
 [package.dependencies]
@@ -342,14 +327,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.2.0"
+version = "6.4.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-6.2.0-py3-none-any.whl", hash = "sha256:8388b74023a138c605fddd0d47cb81dd706232569f56c9aca7d9c7fdb54caeba"},
-    {file = "importlib_metadata-6.2.0.tar.gz", hash = "sha256:9127aad2f49d7203e7112098c12b92e4fd1061ccd18548cdfdc49171a8c073cc"},
+    {file = "importlib_metadata-6.4.1-py3-none-any.whl", hash = "sha256:63ace321e24167d12fbb176b6015f4dbe06868c54a2af4f15849586afb9027fd"},
+    {file = "importlib_metadata-6.4.1.tar.gz", hash = "sha256:eb1a7933041f0f85c94cd130258df3fb0dec060ad8c1c9318892ef4192c47ce1"},
 ]
 
 [package.dependencies]
@@ -632,14 +617,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.0"
+version = "23.1"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
-    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
 
 [[package]]
@@ -902,14 +887,14 @@ files = [
 
 [[package]]
 name = "schedule"
-version = "1.1.0"
+version = "1.2.0"
 description = "Job scheduling for humans."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "schedule-1.1.0-py2.py3-none-any.whl", hash = "sha256:617adce8b4bf38c360b781297d59918fbebfb2878f1671d189f4f4af5d0567a4"},
-    {file = "schedule-1.1.0.tar.gz", hash = "sha256:e6ca13585e62c810e13a08682e0a6a8ad245372e376ba2b8679294f377dfc8e4"},
+    {file = "schedule-1.2.0-py2.py3-none-any.whl", hash = "sha256:415908febaba0bc9a7c727a32efb407d646fe994367ef9157d123aabbe539ea8"},
+    {file = "schedule-1.2.0.tar.gz", hash = "sha256:b4ad697aafba7184c9eb6a1e2ebc41f781547242acde8ceae9a0a25b04c0922d"},
 ]
 
 [[package]]
@@ -1080,10 +1065,7 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
-[extras]
-sonarr = ["buildarr-sonarr"]
-
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "e57c201c32dbd22ac3e3fd9f92413b3b20a40032abef23b1bb41ffcb877a3188"
+content-hash = "f2c6e68fe1a98ccdd4ae72debc96156f27f4835a388e3b6883b54e022c126351"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ packages = [{include = "buildarr_prowlarr"}]
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 prowlarr-py = ">=0.3.2,<0.4.0"
-buildarr = ">=0.4.0,<0.5.0"
-buildarr-sonarr = {version = ">=0.4.1", optional = true}
+buildarr = ">=0.5.0,<0.6.0"
+# buildarr-sonarr = {version = ">=0.4.1", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = "23.3.0"
@@ -54,8 +54,8 @@ mkdocs = "1.4.2"
 mkdocstrings = {extras = ["python"], version = "0.21.2"}
 ruff = "0.0.261"
 
-[tool.poetry.extras]
-sonarr = ["buildarr-sonarr"]
+# [tool.poetry.extras]
+# sonarr = ["buildarr-sonarr"]
 
 [tool.ruff]
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ packages = [{include = "buildarr_prowlarr"}]
 python = ">=3.8,<4.0"
 prowlarr-py = ">=0.3.2,<0.4.0"
 buildarr = ">=0.5.0,<0.6.0"
-# buildarr-sonarr = {version = ">=0.4.1", optional = true}
+buildarr-sonarr = {version = ">=0.5.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = "23.3.0"
@@ -54,8 +54,8 @@ mkdocs = "1.4.2"
 mkdocstrings = {extras = ["python"], version = "0.21.2"}
 ruff = "0.0.261"
 
-# [tool.poetry.extras]
-# sonarr = ["buildarr-sonarr"]
+[tool.poetry.extras]
+sonarr = ["buildarr-sonarr"]
 
 [tool.ruff]
 fix = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ aenum==3.1.12 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:2d544ef7323c088d68abf9a84b9f3f6db0d516fec685e15678b5f84fdb7b8ba0 \
     --hash=sha256:3e531c91860a81f885f7e6e97d219ae9772cb899580084788935dad7d9742ef0 \
     --hash=sha256:8d79c9e3ec997220e355b96b322e672fb56a53e61744138ed838407e3a07b610
-buildarr==0.4.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:8ac557898166e8701d29e2012d9317c293c123e2a705d0ba90b96c5c8439d1ea \
-    --hash=sha256:d7abdf31cbd20afcf019c6b661fd140a67c645fd465dd0d0953940c1df12e73b
+buildarr==0.5.0 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:86a2ae4503f624987bd8e80dedffe069b4d0cbc16f78738e3ffccda894d459cc \
+    --hash=sha256:c33ed1a080d77d135306c4bef7aef98657828b1e71f249d6360bb99db8dddb5e
 certifi==2022.12.7 ; python_version >= "3.8" and python_version < "4" \
     --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
     --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
@@ -99,15 +99,15 @@ decorator==5.1.1 ; python_version >= "3.8" and python_version < "4.0" \
 dnspython==2.3.0 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9 \
     --hash=sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46
-email-validator==1.3.1 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:49a72f5fa6ed26be1c964f0567d931d10bf3fdeeacdf97bc26ef1cd2a44e0bda \
-    --hash=sha256:d178c5c6fa6c6824e9b04f199cf23e79ac15756786573c190d2ad13089411ad2
+email-validator==2.0.0 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:07c61b62ee446e39274b18204afa8e422baf64570776045272b04d10c02f64f6 \
+    --hash=sha256:f4904f4145c11f8de5897afbb8d7db4b465c57f13db1c8c106c16d02bceebd9a
 idna==3.4 ; python_version >= "3.8" and python_version < "4" \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
-importlib-metadata==6.2.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:8388b74023a138c605fddd0d47cb81dd706232569f56c9aca7d9c7fdb54caeba \
-    --hash=sha256:9127aad2f49d7203e7112098c12b92e4fd1061ccd18548cdfdc49171a8c073cc
+importlib-metadata==6.4.1 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:63ace321e24167d12fbb176b6015f4dbe06868c54a2af4f15849586afb9027fd \
+    --hash=sha256:eb1a7933041f0f85c94cd130258df3fb0dec060ad8c1c9318892ef4192c47ce1
 json5==0.9.11 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:1aa54b80b5e507dfe31d12b7743a642e2ffa6f70bf73b8e3d7d1d5fba83d99bd \
     --hash=sha256:4f1e196acc55b83985a51318489f345963c7ba84aa37607e49073066c562e99b
@@ -238,9 +238,9 @@ pyyaml==6.0 ; python_version >= "3.8" and python_version < "4.0" \
 requests==2.28.2 ; python_version >= "3.8" and python_version < "4" \
     --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa \
     --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
-schedule==1.1.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:617adce8b4bf38c360b781297d59918fbebfb2878f1671d189f4f4af5d0567a4 \
-    --hash=sha256:e6ca13585e62c810e13a08682e0a6a8ad245372e376ba2b8679294f377dfc8e4
+schedule==1.2.0 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:415908febaba0bc9a7c727a32efb407d646fe994367ef9157d123aabbe539ea8 \
+    --hash=sha256:b4ad697aafba7184c9eb6a1e2ebc41f781547242acde8ceae9a0a25b04c0922d
 six==1.16.0 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254


### PR DESCRIPTION
* Move all resource deletion processing to the `delete_remote` stage
* Remove all usage of `BaseIntEnum`
* Get `request_timeout` from global state
* Remove explicit definitions of `validate_assignment`
* Update documentation to define autogeneration parameters as defaults