### PR TITLE
Implement instance links with Radarr instances

### DIFF
--- a/docs/configuration/settings/apps/applications.md
+++ b/docs/configuration/settings/apps/applications.md
@@ -50,6 +50,7 @@
     options:
       members:
         - type
+        - instance_name
         - api_key
         - sync_categories
 


### PR DESCRIPTION
Allow instance links to be created within Buildarr between Radarr and Prowlarr instances with `instance_name`.

This eliminates the need to explicitly provide the Radarr API key to Prowlarr application definitions.