### PR TITLE
Add support for external authentication

### DIFF
--- a/buildarr_prowlarr/config/settings/general.py
+++ b/buildarr_prowlarr/config/settings/general.py
@@ -42,6 +42,7 @@ class AuthenticationMethod(BaseEnum):
     none = "none"
     basic = "basic"
     form = "forms"
+    external = "external"
 
 
 class AuthenticationRequired(BaseEnum):


### PR DESCRIPTION
This allows Buildarr to manage Prowlarr instances that have been configured to use external authentication.