### PR TITLE
Remove support for no authentication

### DIFF
--- a/buildarr_prowlarr/config/settings/general.py
+++ b/buildarr_prowlarr/config/settings/general.py
@@ -39,7 +39,6 @@ class AuthenticationMethod(BaseEnum):
     Prowlarr authentication method.
     """
 
-    none = "none"
     basic = "basic"
     form = "forms"
     external = "external"
@@ -227,16 +226,23 @@ class SecurityGeneralSettings(GeneralSettings):
     Prowlarr instance security (authentication) settings.
     """
 
-    authentication: AuthenticationMethod = AuthenticationMethod.none
+    authentication: AuthenticationMethod = AuthenticationMethod.form
     """
     Authentication method for logging into Prowlarr.
-    By default, do not require authentication.
 
     Values:
 
-    * `none` - No authentication
     * `basic` - Authentication using HTTP basic auth (browser popup)
-    * `form` - Authentication using a login page
+    * `form`/`forms` - Authentication using a login page
+    * `external` - External authentication using a reverse proxy (set to disable authentication)
+
+    !!! warning
+
+        When the authentication method is set to `external`,
+        **authentication is disabled within Prowlarr itself.**
+
+        **Make sure access to Prowlarr is secured**, either by using a reverse proxy with
+        forward authentication configured, or not exposing Prowlarr to the public Internet.
 
     Requires a restart of Prowlarr to take effect.
     """
@@ -318,8 +324,8 @@ class SecurityGeneralSettings(GeneralSettings):
         """
         Enforce the following constraints on the validated attributes:
 
-        * If `authentication` is `none`, set the attribute value to `None`.
-        * If `authentication` is a value other than `none` (i.e. require authentication),
+        * If `authentication` is `external`, set the attribute value to `None`.
+        * If `authentication` is a value other than `external` (i.e. require authentication),
           ensure that the attribute set to a value other than `None`.
 
         This will apply to both the local Buildarr configuration and
@@ -335,10 +341,10 @@ class SecurityGeneralSettings(GeneralSettings):
         Returns:
             Validated attribute value
         """
-        if values["authentication"] == AuthenticationMethod.none:
+        if values["authentication"] == AuthenticationMethod.external:
             return None
         elif not value:
-            raise ValueError("required when 'authentication' is not set to 'none'")
+            raise ValueError("required when 'authentication' is not set to 'external'")
         return value
 
 

--- a/docs/configuration/settings/general.md
+++ b/docs/configuration/settings/general.md
@@ -51,7 +51,7 @@ Take care when changing these settings.
     options:
       members:
         - authentication
-        - authenticaion_required
+        - authentication_required
         - username
         - password
         - certificate_validation


### PR DESCRIPTION
Prowlarr 1.0 and later removes support for the `none` authentication method.

This plugin originally was targeted at Prowlarr v0.3, therefore had support for it, but it can be removed as it cannot be used.

Also, fix and update the documentation around the authentication settings.