### PR TITLE
Add Prowlarr instance URL base support

### DIFF
--- a/buildarr_prowlarr/api.py
+++ b/buildarr_prowlarr/api.py
@@ -35,7 +35,7 @@ from prowlarr import ApiClient, Configuration
 from .exceptions import ProwlarrAPIError
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Generator, Optional
+    from typing import Any, Dict, Generator, Optional, Union
 
     from .secrets import ProwlarrSecrets
 
@@ -49,6 +49,7 @@ def prowlarr_api_client(
     *,
     secrets: Optional[ProwlarrSecrets] = None,
     host_url: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> Generator[ApiClient, None, None]:
     """
     Create a Prowlarr API client object, and make it available within a context.
@@ -61,7 +62,10 @@ def prowlarr_api_client(
         Prowlarr API client object
     """
 
-    configuration = Configuration(host=secrets.host_url if secrets else host_url)
+    configuration = Configuration(
+        host=secrets.host_url if secrets else host_url,
+        request_timeout=state.request_timeout,
+    )
 
     root_logger = logging.getLogger()
     configuration.logger_format = cast(
@@ -72,6 +76,8 @@ def prowlarr_api_client(
 
     if secrets:
         configuration.api_key["X-Api-Key"] = secrets.api_key.get_secret_value()
+    elif api_key:
+        configuration.api_key["X-Api-Key"] = api_key
 
     with ApiClient(configuration) as api_client:
         yield api_client
@@ -109,7 +115,7 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
             status_code = res.status_code
             error_message = f"Unexpected response with error code {res.status_code}: {res.text}"
         raise ProwlarrAPIError(
-            f"Unable to retrieve 'initialize.js': {error_message}",
+            f"Unable to retrieve '{url}': {error_message}",
             status_code=status_code,
         )
 
@@ -121,3 +127,119 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
     logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
 
     return res_json
+
+
+def api_get(
+    secrets: Union[ProwlarrSecrets, str],
+    api_url: str,
+    *,
+    api_key: Optional[str] = None,
+    use_api_key: bool = True,
+    expected_status_code: HTTPStatus = HTTPStatus.OK,
+    session: Optional[requests.Session] = None,
+) -> Any:
+    """
+    Send an API `GET` request.
+
+    Args:
+        secrets (Union[ProwlarrSecrets, str]): Secrets metadata, or host URL.
+        api_url (str): API command.
+        expected_status_code (HTTPStatus): Expected response status. Defaults to `200 OK`.
+
+    Returns:
+        Response object
+    """
+
+    if isinstance(secrets, str):
+        host_url = secrets
+        host_api_key = api_key
+    else:
+        host_url = secrets.host_url
+        host_api_key = secrets.api_key.get_secret_value()
+
+    if not use_api_key:
+        host_api_key = None
+
+    url = f"{host_url}/{api_url.lstrip('/')}"
+
+    logger.debug("GET %s", url)
+
+    if not session:
+        session = requests.Session()
+    res = session.get(
+        url,
+        headers={"X-Api-Key": host_api_key} if host_api_key else None,
+        timeout=state.request_timeout,
+    )
+    res_json = res.json()
+
+    logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+
+    if res.status_code != expected_status_code:
+        api_error(method="GET", url=url, response=res)
+
+    return res_json
+
+
+def api_error(
+    method: str,
+    url: str,
+    response: requests.Response,
+    parse_response: bool = True,
+) -> None:
+    """
+    Process an API error response.
+
+    Args:
+        method (str): HTTP method.
+        url (str): API command URL.
+        response (requests.Response): Response metadata.
+        parse_response (bool, optional): Parse response error JSON. Defaults to True.
+
+    Raises:
+        API error
+    """
+
+    error_message = (
+        f"Unexpected response with status code {response.status_code} from from '{method} {url}':"
+    )
+    if parse_response:
+        res_json = response.json()
+        try:
+            error_message += f" {_api_error(res_json)}"
+        except TypeError:
+            for error in res_json:
+                error_message += f"\n{_api_error(error)}"
+        except KeyError:
+            error_message += f" {res_json}"
+    raise ProwlarrAPIError(error_message, status_code=response.status_code)
+
+
+def _api_error(res_json: Any) -> str:
+    """
+    Generate an error message from a response object.
+
+    Args:
+        res_json (Any): Response object
+
+    Returns:
+        String containing one or more error messages
+    """
+
+    try:
+        try:
+            error_message = f"{res_json['propertyName']}: {res_json['errorMessage']}"
+            try:
+                error_message += f" (attempted value: {res_json['attemptedValue']})"
+            except KeyError:
+                pass
+            return error_message
+        except KeyError:
+            pass
+        try:
+            return f"{res_json['message']}\n{res_json['description']}"
+        except KeyError:
+            pass
+        return res_json["message"]
+    except KeyError:
+        return f"(Unsupported error JSON format) {res_json}"

--- a/buildarr_prowlarr/secrets.py
+++ b/buildarr_prowlarr/secrets.py
@@ -20,16 +20,16 @@ Prowlarr plugin secrets file model.
 from __future__ import annotations
 
 from http import HTTPStatus
-from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Optional, cast
 
 import prowlarr
 
 from buildarr.secrets import SecretsPlugin
 from buildarr.types import NonEmptyStr, Port
 from prowlarr.exceptions import UnauthorizedException
+from pydantic import validator
 
-from .api import get_initialize_js, prowlarr_api_client
+from .api import api_get, get_initialize_js, prowlarr_api_client
 from .exceptions import ProwlarrAPIError, ProwlarrSecretsUnauthorizedError
 from .types import ArrApiKey, ProwlarrProtocol
 
@@ -55,65 +55,113 @@ class ProwlarrSecrets(_ProwlarrSecrets):
     hostname: NonEmptyStr
     port: Port
     protocol: ProwlarrProtocol
+    url_base: Optional[str]
     api_key: ArrApiKey
+    version: NonEmptyStr
 
     @property
     def host_url(self) -> str:
-        return f"{self.protocol}://{self.hostname}:{self.port}"
+        return self._get_host_url(
+            protocol=self.protocol,
+            hostname=self.hostname,
+            port=self.port,
+            url_base=self.url_base,
+        )
+
+    @validator("url_base")
+    def validate_url_base(cls, value: Optional[str]) -> Optional[str]:
+        return f"/{value.strip('/')}" if value and value.strip("/") else None
 
     @classmethod
-    def from_url(cls, base_url: str, api_key: str) -> Self:
-        url_obj = urlparse(base_url)
-        hostname_port = url_obj.netloc.rsplit(":", 1)
-        hostname = hostname_port[0]
-        protocol = url_obj.scheme
-        port = (
-            int(hostname_port[1])
-            if len(hostname_port) > 1
-            else (443 if protocol == "https" else 80)
-        )
-        return cls(
-            **{  # type: ignore[arg-type]
-                "hostname": hostname,
-                "port": port,
-                "protocol": protocol,
-                "api_key": api_key,
-            },
-        )
+    def _get_host_url(
+        cls,
+        protocol: str,
+        hostname: str,
+        port: int,
+        url_base: Optional[str],
+    ) -> str:
+        return f"{protocol}://{hostname}:{port}{url_base or ''}"
 
     @classmethod
     def get(cls, config: ProwlarrConfig) -> Self:
-        if config.api_key:
-            api_key = config.api_key
-        else:
-            try:
-                api_key = get_initialize_js(host_url=config.host_url)["apiKey"]
-            except ProwlarrAPIError as err:
-                if err.status_code == HTTPStatus.UNAUTHORIZED:
-                    raise ProwlarrSecretsUnauthorizedError(
-                        "Unable to retrieve the API key for the Prowlarr instance "
-                        f"at '{config.host_url}': Authentication is enabled. "
-                        "Please try manually setting the "
-                        "'Settings -> General -> Authentication Required' attribute "
-                        "to 'Disabled for Local Addresses', or if that does not work, "
-                        "explicitly define the API key in the Buildarr configuration.",
-                    ) from None
-                else:
-                    raise
-            # TODO: Switch to `prowlarr.InitializeJsApi.get_initialize_js` when fixed.
-            # with prowlarr_api_client(host_url=config.host_url) as api_client:
-            #     api_key = prowlarr.InitializeJsApi(api_client).get_initialize_js().api_key
-        return cls(
+        return cls.get_from_url(
             hostname=config.hostname,
             port=config.port,
             protocol=config.protocol,
-            api_key=api_key,
+            url_base=config.url_base,
+            api_key=config.api_key.get_secret_value() if config.api_key else None,
+        )
+
+    @classmethod
+    def get_from_url(
+        cls,
+        hostname: str,
+        port: int,
+        protocol: str,
+        url_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> Self:
+        url_base = cls.validate_url_base(url_base)
+        host_url = cls._get_host_url(
+            protocol=protocol,
+            hostname=hostname,
+            port=port,
+            url_base=url_base,
+        )
+        if not api_key:
+            unauthorized_error = (
+                "Unable to retrieve the API key for the Prowlarr instance "
+                f"at '{host_url}': Authentication is enabled. "
+                "Please try manually setting the "
+                "'Settings -> General -> Authentication Required' attribute "
+                "to 'Disabled for Local Addresses', or if that does not work, "
+                "explicitly define the API key in the Buildarr configuration."
+            )
+            # When auto-fetching the API key, try loading initialize.json first
+            # (used by newer versions of Prowlarr).
+            try:
+                initialize_json = api_get(host_url, "/initialize.json")
+            except ProwlarrAPIError as json_err:
+                if json_err.status_code == HTTPStatus.NOT_FOUND:
+                    # If initialize.json was not found, try initialize.js instead
+                    # (used by older versions of Prowlarr).
+                    try:
+                        initialize_js = get_initialize_js(host_url=host_url)
+                    except ProwlarrAPIError as js_err:
+                        if js_err.status_code == HTTPStatus.UNAUTHORIZED:
+                            raise ProwlarrSecretsUnauthorizedError(unauthorized_error) from None
+                        else:
+                            raise
+                    else:
+                        api_key = initialize_js["apiKey"]
+                elif json_err.status_code == HTTPStatus.UNAUTHORIZED:
+                    raise ProwlarrSecretsUnauthorizedError(unauthorized_error) from None
+                else:
+                    raise
+            else:
+                api_key = initialize_json["apiKey"]
+        try:
+            with prowlarr_api_client(host_url=host_url, api_key=api_key) as api_client:
+                system_status = prowlarr.SystemApi(api_client).get_system_status()
+        except UnauthorizedException:
+            raise ProwlarrSecretsUnauthorizedError(
+                (
+                    f"Incorrect API key for the Prowlarr instance at '{host_url}'. "
+                    "Please check that the API key is set correctly in the Buildarr "
+                    "configuration, and that it is set to the value as shown in "
+                    "'Settings -> General -> API Key' on the Prowlarr instance."
+                ),
+            ) from None
+        return cls(
+            hostname=cast(NonEmptyStr, hostname),
+            port=cast(Port, port),
+            protocol=cast(ProwlarrProtocol, protocol),
+            url_base=url_base,
+            api_key=cast(ArrApiKey, api_key),
+            version=system_status.version,
         )
 
     def test(self) -> bool:
-        with prowlarr_api_client(secrets=self) as api_client:
-            try:
-                prowlarr.SystemApi(api_client).get_system_status()
-            except UnauthorizedException:
-                return False
+        # We already perform API requests as part of instantiating the secrets object.
+        # If the object exists, then the connection test is already successful.
         return True

--- a/docs/configuration/host.md
+++ b/docs/configuration/host.md
@@ -6,6 +6,8 @@
         - hostname
         - port
         - protocol
+        - url_base
         - api_key
         - version
+        - image
         - settings


### PR DESCRIPTION
https://github.com/buildarr/buildarr-prowlarr/issues/53

* Add the `url_base` host configuration attribute.
* When dumping host configurations, use the provided path as the URL base.
* Add support for auto-fetching API keys from newer versions of Prowlarr using the `initialize.json` endpoint.
* Add support for auto-fetching API keys when dumping instance configurations, by simply pressing Enter without specifying an API key at the prompt.
* Read and store the instance version as secrets metadata (instead of fetching it in a separate API request when creating the instance configuration).
* Use the configured Buildarr request timeout for Prowlarr API requests.